### PR TITLE
Add !Loop, !Lookup and !LookupAll tags

### DIFF
--- a/emrichen/__init__.py
+++ b/emrichen/__init__.py
@@ -3,12 +3,7 @@ from .template import Template
 from .tags import Var
 
 
-__all__ = [
-    'Context',
-    'Template',
-    'Var',
-    'emrichen',
-]
+__all__ = ['Context', 'Template', 'Var', 'emrichen']
 
 
 def emrichen(template, *variable_sources, **override_variables):
@@ -25,4 +20,3 @@ def emrichen(template, *variable_sources, **override_variables):
     t = Template.parse(template, 'yaml')
 
     return t.render(c)
-

--- a/emrichen/__main__.py
+++ b/emrichen/__main__.py
@@ -3,9 +3,10 @@ import os
 import sys
 
 from .context import Context
-from .template import Template
 from .input import PARSERS
 from .output import RENDERERS
+from .template import Template
+
 
 def get_parser():
     parser = argparse.ArgumentParser(

--- a/emrichen/__main__.py
+++ b/emrichen/__main__.py
@@ -32,7 +32,8 @@ def get_parser():
         ),
     )
     parser.add_argument(
-        '--var-file', '-f',
+        '--var-file',
+        '-f',
         dest='var_files',
         metavar='VAR_FILE',
         type=argparse.FileType('r'),
@@ -41,17 +42,19 @@ def get_parser():
         help=(
             'A YAML file containing an object whose top-level keys will be defined as variables. '
             'May be specified multiple times.'
-        )
+        ),
     )
     parser.add_argument(
-        '--define', '-D',
+        '--define',
+        '-D',
         metavar='VAR=VALUE',
         action='append',
         default=[],
         help='Defines a single variable. May be specified multiple times.',
     )
     parser.add_argument(
-        '--output-file', '-o',
+        '--output-file',
+        '-o',
         type=argparse.FileType('w'),
         default=sys.stdout,
         help='Output file. If unspecified, the template output is written into stdout.',
@@ -66,7 +69,8 @@ def get_parser():
         ),
     )
     parser.add_argument(
-        '--include-env', '-e',
+        '--include-env',
+        '-e',
         action='store_true',
         default=False,
         help='Expose process environment variables to the template.',
@@ -94,14 +98,12 @@ def main(args=None):
     if args.include_env:
         variable_sources.append(os.environ)
 
-    args.output_format = (
-        args.output_format or
-        determine_format(args.output_file, RENDERERS, default='yaml')
+    args.output_format = args.output_format or determine_format(
+        args.output_file, RENDERERS, default='yaml'
     )
 
-    args.template_format = (
-        args.template_format or
-        determine_format(args.template_file, PARSERS, default='yaml')
+    args.template_format = args.template_format or determine_format(
+        args.template_file, PARSERS, default='yaml'
     )
 
     context = Context(*variable_sources, **override_variables)

--- a/emrichen/context.py
+++ b/emrichen/context.py
@@ -16,6 +16,9 @@ class Context(object):
     def __getitem__(self, key):
         return self.variables[key]
 
+    def __contains__(self, key):
+        return key in self.variables
+
     def enrich(self, value):
         """
         Given a YAML value, performs our registered transformations on it.
@@ -51,3 +54,7 @@ class Context(object):
                     self.variables.update(yaml_document)
 
         self.variables.update(override_variables)
+
+    def subcontext(self, override_variables):
+        # TODO: this could use less copying, but that's a future optimization
+        return self.__class__(dict(self.variables, **override_variables))

--- a/emrichen/tags/__init__.py
+++ b/emrichen/tags/__init__.py
@@ -1,6 +1,6 @@
 from .format import Format
 from .var import Var
 from .loop import Loop
+from .lookup import Lookup, LookupAll
 
-
-__all__ = ['Format', 'Var', 'Loop']
+__all__ = ['Format', 'Var', 'Loop', 'Lookup', 'LookupAll']

--- a/emrichen/tags/__init__.py
+++ b/emrichen/tags/__init__.py
@@ -1,5 +1,6 @@
 from .format import Format
 from .var import Var
+from .loop import Loop
 
 
-__all__ = ['Format', 'Var']
+__all__ = ['Format', 'Var', 'Loop']

--- a/emrichen/tags/base.py
+++ b/emrichen/tags/base.py
@@ -10,15 +10,12 @@ class BaseMeta(type):
 
 class BaseTag(metaclass=BaseMeta):
     __slots__ = ['data']
+    value_types = (str,)
 
     def __init__(self, data):
         self.data = data
+        if not isinstance(data, self.value_types):
+            raise TypeError(f'{self}: data not of valid type (valid types are {self.value_types}')
 
     def __str__(self):
         return f'{self.__class__.__name__}({repr(self.data)})'
-
-    @classmethod
-    def load(cls, loader, node):
-        data = loader.construct_scalar(node)
-        assert isinstance(data, str)
-        return cls(data)

--- a/emrichen/tags/format.py
+++ b/emrichen/tags/format.py
@@ -1,5 +1,3 @@
-import yaml
-
 from .base import BaseTag
 
 

--- a/emrichen/tags/lookup.py
+++ b/emrichen/tags/lookup.py
@@ -1,0 +1,25 @@
+from .base import BaseTag
+from functools import lru_cache
+import jsonpath_rw
+
+
+@lru_cache()
+def parse_jsonpath(expr):
+    return jsonpath_rw.parse(expr)
+
+
+def find_jsonpath_in_context(jsonpath_str, context):
+    return parse_jsonpath(jsonpath_str).find(context)
+
+
+class Lookup(BaseTag):
+    def enrich(self, context):
+        matches = find_jsonpath_in_context(self.data, context)
+        if not matches:
+            raise KeyError(f'{self}: no matches for {self.data}')
+        return matches[0].value
+
+
+class LookupAll(BaseTag):
+    def enrich(self, context):
+        return [m.value for m in find_jsonpath_in_context(self.data, context)]

--- a/emrichen/tags/loop.py
+++ b/emrichen/tags/loop.py
@@ -1,0 +1,48 @@
+from collections import Mapping, Sequence
+
+from .base import BaseTag
+
+
+class Loop(BaseTag):
+    value_types = (dict,)
+
+    def enrich(self, context):
+        as_ = str(self.data.get('as', 'item'))
+        index_as = str(self.data.get('index_as') or '')
+        from ..template import Template
+
+        template = self.data.get('template')
+        if template is None:
+            raise ValueError(f'{self}: missing template')
+        template = Template([template])
+        compact = bool(self.data.get('compact'))
+        output = []
+        for index, value in self.get_iterable(context):
+            subcontext = {as_: value}
+            if index_as:
+                subcontext[index_as] = index
+            value = template.enrich(context.subcontext(subcontext))[0]
+            if compact and not value:
+                continue
+            output.append(value)
+        return output
+
+    def get_iterable(self, context):
+        over = self.data.get('over')
+
+        if isinstance(over, str) and over in context:
+            # This does mean you can't explicitly iterate over strings that are keys
+            # in the context, but if you really do need to do that, you may need to
+            # rethink your approach anyway.
+            raise ValueError(
+                f'{self}: `over` value exists within the context; did you mean `!Var {over}`?'
+            )
+
+        if hasattr(over, 'enrich'):
+            over = over.enrich(context)
+        if isinstance(over, Mapping):
+            return over.items()
+        elif isinstance(over, Sequence):
+            return enumerate(over)
+
+        raise ValueError(f'{self}: over value {over} is not iterable')

--- a/emrichen/tags/var.py
+++ b/emrichen/tags/var.py
@@ -1,5 +1,3 @@
-import yaml
-
 from .base import BaseTag
 
 

--- a/emrichen/template.py
+++ b/emrichen/template.py
@@ -1,6 +1,6 @@
-from .output import render
 from .context import Context
 from .input import parse
+from .output import render
 
 
 class Template(object):

--- a/examples/loop.yml
+++ b/examples/loop.yml
@@ -1,0 +1,11 @@
+domains:
+  !Loop
+    over: !Var domain_names
+    as: domain_name
+    index_as: domain_index
+    template:
+      apiVersion: v1
+      kind: DomainName
+      metadata:
+        name: !Var domain_name
+        index: !Var domain_index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 105
+py36 = true
+skip-string-normalization = true

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
-import os
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 setup(
     name='emrichen',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
             'emrichen = emrichen.__main__:main',
         ]
     },
-    install_requires=["PyYAML", "pyaml"],
+    install_requires=["PyYAML", "pyaml", "jsonpath-rw~=1.4.0"],
     tests_require=["pytest"],
     setup_requires=["pytest-runner"],
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,12 +9,17 @@ from emrichen.output import RENDERERS
 
 @pytest.mark.parametrize('output_format', list(RENDERERS))
 def test_cli_json_input(examples_dir, output_format, capsys):
-    main([
-        os.path.join(examples_dir, 'example.json'),
-        '-D', 'kitten=Miuku',
-        '-D', 'sound=pikkuruinen miu',
-        '--output-format', output_format,
-    ])
+    main(
+        [
+            os.path.join(examples_dir, 'example.json'),
+            '-D',
+            'kitten=Miuku',
+            '-D',
+            'sound=pikkuruinen miu',
+            '--output-format',
+            output_format,
+        ]
+    )
     out, err = capsys.readouterr()
     parse(out, format=output_format)
     assert 'pikkuruinen miu' in out
@@ -22,10 +27,14 @@ def test_cli_json_input(examples_dir, output_format, capsys):
 
 def test_cli_kubernetes_example(examples_dir, capsys):
     tag = 'you_are_it'
-    main([
-        os.path.join(examples_dir, 'kubernetes', 'deployment.in.yml'),
-        '-f', os.path.join(examples_dir, 'kubernetes', 'vars.yml'),
-        '-D', f'tag={tag}',
-    ])
+    main(
+        [
+            os.path.join(examples_dir, 'kubernetes', 'deployment.in.yml'),
+            '-f',
+            os.path.join(examples_dir, 'kubernetes', 'vars.yml'),
+            '-D',
+            f'tag={tag}',
+        ]
+    )
     out, err = capsys.readouterr()
     assert f'tracon/kompassi:{tag}' in out

--- a/tests/test_emrichen.py
+++ b/tests/test_emrichen.py
@@ -1,4 +1,4 @@
-from emrichen import emrichen, Template, Context
+from emrichen import Context, Template, emrichen
 
 TEMPLATE = """
 ---

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,47 @@
+import pytest
+
+from emrichen import Context, Template, Var
+from emrichen.tags import Loop
+
+LOOP_TEST_CONTEXT = {'domain_names': ['hernekeit.to', 'vii.na', 'teli.ne', 'johann.es']}
+
+
+def test_loop(examples_dir):
+    with open(f'{examples_dir}/loop.yml', 'r') as inf:
+        template = Template.parse(inf, 'yaml')
+    ctx = Context(LOOP_TEST_CONTEXT)
+    output = template.render(ctx)
+    assert (
+        output.strip()
+        == '''
+domains:
+- apiVersion: v1
+  kind: DomainName
+  metadata:
+    index: 0
+    name: hernekeit.to
+- apiVersion: v1
+  kind: DomainName
+  metadata:
+    index: 1
+    name: vii.na
+- apiVersion: v1
+  kind: DomainName
+  metadata:
+    index: 2
+    name: teli.ne
+- apiVersion: v1
+  kind: DomainName
+  metadata:
+    index: 3
+    name: johann.es
+'''.strip()
+    )
+
+
+def test_loop_user_friendliness():
+    template = Template([Loop({'over': 'domain_names', 'template': Var('item')})])
+    ctx = Context(LOOP_TEST_CONTEXT)
+    with pytest.raises(ValueError) as ei:
+        output = template.render(ctx)
+    assert 'did you mean' in str(ei.value)


### PR DESCRIPTION
# Loops

Fixes #2.

This deviates from the spec in the ticket by allowing iteration over literals too, rather than just variables.

```yaml
domains:
  !Loop
    over: !Var domain_names
    as: domain_name
    index_as: domain_index
    template:
      apiVersion: v1
      kind: DomainName
      metadata:
        name: !Var domain_name
        index: !Var domain_index
```

```yaml
domains:
  !Loop
    over:
    - hipsis
    - hopsis
    - hepsis
```

# Lookups

Using JSONPath, as discussed.

```yaml
first_names: !LookupAll people[*].first_name
last_names: !LookupAll people[*].last_name
```

```yaml
people:
  !Loop
    over: !Var people
    as: person
    template:
      - !Lookup person.last_name
      - !Lookup person.first_name
```