### PR TITLE
Fix four interconnected bugs

### DIFF
--- a/emrichen/tags/all.py
+++ b/emrichen/tags/all.py
@@ -7,7 +7,7 @@ class All(BaseTag):
     example: "`!All [true, false]`"
     description: Returns true iff all the items of the iterable argument are truthy.
     """
-    value_types = (list,)
+    value_types = (list, BaseTag)
 
     def enrich(self, context):
         return all(context.enrich(item) for item in self.data)

--- a/emrichen/tags/any.py
+++ b/emrichen/tags/any.py
@@ -7,7 +7,7 @@ class Any(BaseTag):
     example: "`!Any [true, false]`"
     description: Returns true iff at least one of the items of the iterable argument is truthy.
     """
-    value_types = (list,)
+    value_types = (list, BaseTag)
 
     def enrich(self, context):
         return any(context.enrich(item) for item in self.data)

--- a/emrichen/tags/compose.py
+++ b/emrichen/tags/compose.py
@@ -16,8 +16,8 @@ class Compose(BaseTag):
     value_types = (dict,)
 
     def enrich(self, context):
-        value = context.enrich(self.data.get('value'))
+        value = self.data.get('value')
         for tag_name in reversed(self.data['tags']):
             tag_class = tag_registry[tag_name]
-            value = context.enrich(tag_class(value))
-        return value
+            value = tag_class(value)
+        return context.enrich(value)

--- a/emrichen/tags/concat.py
+++ b/emrichen/tags/concat.py
@@ -7,7 +7,7 @@ class Concat(BaseTag):
     example: "`!Concat [[1, 2], [3, 4]]`"
     description: Concatenates lists.
     """
-    value_types = (object,)
+    value_types = (list, BaseTag)
 
     def enrich(self, context):
         result = []

--- a/emrichen/tags/concat.py
+++ b/emrichen/tags/concat.py
@@ -7,10 +7,10 @@ class Concat(BaseTag):
     example: "`!Concat [[1, 2], [3, 4]]`"
     description: Concatenates lists.
     """
-    value_types = (list,)
+    value_types = (object,)
 
     def enrich(self, context):
         result = []
-        for iterable in self.data:
-            result.extend(context.enrich(iterable))
+        for iterable in context.enrich(self.data):
+            result.extend(iterable)
         return result

--- a/emrichen/tags/format.py
+++ b/emrichen/tags/format.py
@@ -11,7 +11,7 @@ class JSONPathFormatter(string.Formatter):
         self.context = context
 
     def get_field(self, field_name, args, kwargs):
-        return (self._get_in_context(field_name), 0)
+        return (self.context.enrich(self._get_in_context(field_name)), 0)
 
     def _get_in_context(self, selector):
         matches = find_jsonpath_in_context(selector, self.context)

--- a/emrichen/tags/hash.py
+++ b/emrichen/tags/hash.py
@@ -6,7 +6,7 @@ from .base import BaseTag
 class _BaseHash(BaseTag):
     """
     arguments: Data to hash
-    example: "`!{name} 'Törkylempijävongahdus'"
+    example: "`!{name} 'some data to hash'`"
     description: Hashes the given data using the {name} algorithm. If the data is not binary, it is converted to UTF-8 bytes.
     """
     hasher = None

--- a/emrichen/tags/join.py
+++ b/emrichen/tags/join.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 from .base import BaseTag
 
 
@@ -14,14 +16,16 @@ class Join(BaseTag):
     description: Joins a list of items together with a separator. The result is always a string.
     """
 
-    value_types = (dict, list)
+    value_types = (dict, list, BaseTag)
 
     def enrich(self, context):
-        if isinstance(self.data, list):
-            items = context.enrich(self.data)
-            separator = ' '
-        else:
-            items = context.enrich(self.data['items'])
+        if isinstance(self.data, Mapping):
             separator = context.enrich(self.data.get('separator', ' '))
+            items = context.enrich(self.data['items'])
+        else:
+            separator = ' '
+            items = context.enrich(self.data)
+            if not isinstance(items, list):
+                raise TypeError('{self}: must resolve to a list'.format(self=self))
 
         return separator.join(str(i) for i in items)

--- a/emrichen/tags/merge.py
+++ b/emrichen/tags/merge.py
@@ -9,10 +9,10 @@ class Merge(BaseTag):
     example: '`!Merge [{a: 5}, {b: 6}]`'
     description: Merges objects. For overlapping keys the last one takes precedence.
     """
-    value_types = (list,)
+    value_types = (list, BaseTag)
 
     def enrich(self, context):
         result = OrderedDict()
-        for iterable in self.data:
-            result.update(context.enrich(iterable))
+        for iterable in context.enrich(self.data):
+            result.update(iterable)
         return result

--- a/emrichen/tags/urlencode.py
+++ b/emrichen/tags/urlencode.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from urllib.parse import quote_plus, urlparse, urlunparse, parse_qsl, urlencode
 
 from .base import BaseTag
@@ -42,29 +43,34 @@ class URLEncode(BaseTag):
     TODO Add query_mode: append|replace (currently append)
     """
 
-    value_types = (object,)
+    value_types = (dict, str, BaseTag)
 
     def enrich(self, context):
-        data = context.enrich(self.data)
+        if isinstance(self.data, Mapping):
+            url = context.enrich(self.data.get('url'))
+            query = context.enrich(self.data.get('query'))
 
-        if isinstance(data, str):
-            # 1. Just encode a plain string
-            return quote_plus(data)
+            if url is not None:  # empty string ok!
+                # 3. Combine a base URL and query string parameters
+                url = urlparse(url)
+                query = query or {}
+                query = parse_qsl(url.query) + list(query.items())
+                url = url._replace(query=urlencode(query))
+                return urlunparse(url)
 
-        url = data.get('url')
-        query = data.get('query')
+            elif query is not None:  # empty object ok!
+                # 2. Form a query string
+                return urlencode(query)
 
-        if url is not None:  # empty string ok!
-            # 3. Combine a base URL and query string parameters
-            url = urlparse(url)
-            query = query or {}
-            query = parse_qsl(url.query) + list(query.items())
-            url = url._replace(query=urlencode(query))
-            return urlunparse(url)
-
-        elif query is not None:  # empty object ok!
-            # 2. Form a query string
-            return urlencode(query)
+            else:
+                raise TypeError('{self}: needs url, query or both'.format(self=self))
 
         else:
-            raise TypeError('needs url, query or both')
+            data = context.enrich(self.data)
+
+            if isinstance(data, str):
+                # 1. Just encode a plain string
+                return quote_plus(data)
+
+            else:
+                raise TypeError('{self}: single argument must be a string (got {what})'.format(self=self, what=type(data)))

--- a/emrichen/tags/urlencode.py
+++ b/emrichen/tags/urlencode.py
@@ -42,15 +42,17 @@ class URLEncode(BaseTag):
     TODO Add query_mode: append|replace (currently append)
     """
 
-    value_types = (str, dict)
+    value_types = (object,)
 
     def enrich(self, context):
-        if isinstance(self.data, str):
-            # 1. Just encode a plain string
-            return quote_plus(self.data)
+        data = context.enrich(self.data)
 
-        url = context.enrich(self.data.get('url'))
-        query = context.enrich(self.data.get('query'))
+        if isinstance(data, str):
+            # 1. Just encode a plain string
+            return quote_plus(data)
+
+        url = data.get('url')
+        query = data.get('query')
 
         if url is not None:  # empty string ok!
             # 3. Combine a base URL and query string parameters

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -28,3 +28,40 @@ def test_compose_syntax(format):
     ctx = Context(CONTEXT)
     output = template.enrich(ctx)[0]
     assert base64.b64decode(output).decode() == 'hello world'
+
+
+def test_compose_context():
+    """
+    There was a bug in handling of Context in Compose that would cause Loop within Compose
+    to not propagate `as`, `index_as` etc within `template`. Prior to fixing of that bug,
+    this test would `KeyError: item`.
+    """
+    template = Template.parse('''
+!Concat,Loop
+  over:
+    - [1, 2, 3]
+    - [4, 5, 6]
+  as: item
+  template: !Var item
+''')
+    assert template.enrich({}) == [[1, 2, 3, 4, 5, 6]]
+
+
+def test_compose_context_json():
+    template = Template.parse('''
+{
+    "!Concat": {
+        "!Loop": {
+            "over": [
+                [1, 2, 3],
+                [4, 5, 6]
+            ],
+            "as": "item",
+            "template": {
+                "!Var": "item"
+            }
+        }
+    }
+}
+''', 'json')
+    assert template.enrich({}) == [[1, 2, 3, 4, 5, 6]]

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -20,3 +20,18 @@ b:
 
 def test_concat():
     assert Template.parse(TEMPLATE).enrich(Context()) == [[1, 2, 3, 4, 5, 6]]
+
+
+def test_concat_var():
+    """
+    Concat must also support concatenating non-literal lists, ie. return values
+    of list-valued tags.
+    """
+    assert Template.parse('''
+!Defaults
+a:
+  - [1, 2, 3]
+  - [4, 5, 6]
+---
+!Concat,Var a
+''')

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -8,3 +8,12 @@ def test_format():
     ctx = Context({'person': {'name': 'Pipimi'}, 'chance': .99})
     output = template.enrich(ctx)[0]
     assert output == 'This tests formatting. Pipimi 99% == 0.99000'
+
+
+def test_format_var():
+    assert Template.parse('''
+!Defaults
+a: !Op [2, plus, 3]
+---
+!Format "five {a}"
+    ''').enrich({}) == ['five 5']

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -6,10 +6,11 @@ TEMPLATE = """
 a:
   foo: 5
   bar: 6
----
-!Merge
+b:
   - !Var a
   - bar: 7
+---
+!Merge,Var b
 """
 
 

--- a/tests/test_urlencode.py
+++ b/tests/test_urlencode.py
@@ -1,3 +1,5 @@
+import pytest
+
 from emrichen import Template
 
 
@@ -26,6 +28,7 @@ def test_urlencode_url():
     assert template.enrich({}) == ['https://example.com/?foo=x&bar=xyzzy']
 
 
+@pytest.mark.xfail
 def test_urlencode_enrich_str():
     assert Template.parse('''
 !Defaults

--- a/tests/test_urlencode.py
+++ b/tests/test_urlencode.py
@@ -28,7 +28,6 @@ def test_urlencode_url():
     assert template.enrich({}) == ['https://example.com/?foo=x&bar=xyzzy']
 
 
-@pytest.mark.xfail
 def test_urlencode_enrich_str():
     assert Template.parse('''
 !Defaults


### PR DESCRIPTION
I was working on a complex template and noticed `!Concat,Loop` did not work as expected (`KeyError` on `as:` variable). This in turn led to the discovery of multiple bugs:

1. `!Concat` did not support flattening anything else than a literal list,
2. `!Compose` was breaking tags that use sub-context, such as `!Loop`,
3. `!Format` did not enrich whatever it was substituting, and
4. `!URLEncode`, when composed, had ever worked only due to a side-effect of 2.